### PR TITLE
Add GitHub PR Reviewer Workflow

### DIFF
--- a/microagents/pr_reviewer.md
+++ b/microagents/pr_reviewer.md
@@ -1,0 +1,66 @@
+---
+triggers:
+- pr review
+- pull request review
+- code review
+---
+
+# PR Reviewer Microagent
+
+You are a PR Reviewer microagent, specialized in reviewing code changes in pull requests. Your goal is to provide thorough, constructive feedback on code quality, potential bugs, security issues, and performance concerns.
+
+## Review Process
+
+When reviewing a pull request, follow these steps:
+
+1. **Understand the Context**: Read the PR description and title to understand the purpose of the changes.
+
+2. **Analyze the Changes**: Examine the diff to understand what code was added, modified, or removed.
+
+3. **Provide Structured Feedback**: Organize your review into these sections:
+   - **Summary**: Brief overview of the changes and their purpose
+   - **Code Quality**: Assess code style, readability, maintainability
+   - **Potential Issues**: Identify bugs, edge cases, or logical errors
+   - **Security Concerns**: Flag any security vulnerabilities
+   - **Performance Considerations**: Note any performance implications
+   - **Suggested Improvements**: Provide specific, actionable suggestions
+
+4. **Be Constructive**: Focus on being helpful rather than critical. Explain why changes are needed, not just what needs to change.
+
+## Review Guidelines
+
+- **Be Specific**: Point to exact lines or blocks of code when giving feedback
+- **Prioritize Issues**: Focus on critical issues first (security, bugs) before style concerns
+- **Suggest Solutions**: Don't just point out problems; offer potential solutions
+- **Consider the Big Picture**: Evaluate how changes fit into the overall architecture
+- **Be Respectful**: Maintain a professional, constructive tone
+
+## Example Review Format
+
+```
+## Summary
+[Brief overview of the PR and its purpose]
+
+## Code Quality
+- [Specific feedback on code style, organization, etc.]
+- [Highlight good practices observed]
+
+## Potential Issues
+- [Bugs or logical errors identified]
+- [Edge cases that might not be handled]
+
+## Security Concerns
+- [Any security vulnerabilities or risks]
+- [Suggestions for improving security]
+
+## Performance Considerations
+- [Performance implications of the changes]
+- [Suggestions for optimization]
+
+## Suggested Improvements
+- [Specific, actionable suggestions for improvement]
+- [Alternative approaches to consider]
+```
+
+Remember that your goal is to help improve the code quality and ensure the changes are safe, efficient, and maintainable.
+

--- a/openhands/integrations/github/README.md
+++ b/openhands/integrations/github/README.md
@@ -1,0 +1,57 @@
+# GitHub Integration
+
+This directory contains the GitHub integration for OpenHands, including:
+
+- GitHub API client for repository operations
+- PR creation functionality
+- PR review automation
+
+## PR Reviewer
+
+The PR Reviewer is a feature that automatically reviews pull requests using OpenHands AI. It can:
+
+1. Detect new PRs via GitHub webhooks
+2. Create a new conversation in OpenHands
+3. Analyze the code changes
+4. Generate review comments
+5. Optionally create a new PR with suggested fixes
+
+### Setup
+
+To set up the PR Reviewer, you need to:
+
+1. Configure a GitHub webhook to point to your OpenHands instance
+2. Set the following environment variables:
+
+```
+WEBHOOK_SECRET=your_webhook_secret
+WEBHOOK_ALLOWED_REPOS=owner/repo1,owner/repo2
+WEBHOOK_AUTO_FIX=false
+```
+
+### Webhook Configuration
+
+In your GitHub repository settings:
+
+1. Go to Settings > Webhooks > Add webhook
+2. Set the Payload URL to `https://your-openhands-instance.com/api/webhooks/github`
+3. Set the Content type to `application/json`
+4. Set the Secret to the same value as your `WEBHOOK_SECRET` environment variable
+5. Select "Let me select individual events" and choose "Pull requests"
+6. Click "Add webhook"
+
+### How It Works
+
+1. When a PR is opened or updated, GitHub sends a webhook event to OpenHands
+2. OpenHands validates the webhook signature and processes the event
+3. A new conversation is created with the PR details and diff
+4. The OpenHands AI analyzes the code changes and generates a review
+5. The review is posted as a comment on the PR
+6. If auto-fix is enabled, OpenHands may create a new PR with suggested fixes
+
+### Security Considerations
+
+- The webhook endpoint validates the signature using the secret to ensure the request is from GitHub
+- Only repositories in the allowed list can trigger reviews
+- The GitHub token used for API calls should have minimal permissions (read access to PRs and write access for commenting)
+

--- a/openhands/integrations/github/pr_reviewer.py
+++ b/openhands/integrations/github/pr_reviewer.py
@@ -1,0 +1,407 @@
+import dataclasses
+import os
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field, SecretStr
+
+from openhands.core.logger import openhands_logger as logger
+from openhands.events.types import EventType
+from openhands.integrations.github.github_service import GitHubService
+from openhands.integrations.service_types import RequestMethod
+from openhands.server.session.conversation_init_data import ConversationInitData
+from openhands.server.shared import conversation_manager
+from openhands.storage.data_models.conversation_metadata import ConversationTrigger
+
+
+class PRReviewResult(BaseModel):
+    """Result of a PR review."""
+
+    conversation_id: str = Field(
+        ..., description='ID of the conversation created for the review'
+    )
+    review_comments: list[str] = Field(
+        default_factory=list, description='Review comments'
+    )
+    fix_pr_url: Optional[str] = Field(
+        None, description='URL of the PR with fixes, if created'
+    )
+
+
+class PRReviewer:
+    """
+    PR Reviewer for GitHub pull requests.
+
+    This class handles the process of reviewing GitHub pull requests using OpenHands AI.
+    It creates a new conversation, analyzes the PR changes, and generates review comments.
+    Optionally, it can create a new PR with suggested fixes.
+    """
+
+    def __init__(
+        self,
+        repo_name: str,
+        pr_number: int,
+        auto_fix: bool = False,
+        github_token: Optional[SecretStr] = None,
+    ):
+        """
+        Initialize the PR reviewer.
+
+        Args:
+            repo_name: The repository name in format 'owner/repo'
+            pr_number: The PR number
+            auto_fix: Whether to automatically create PRs with fixes
+            github_token: GitHub token for API access (optional, will use system token if not provided)
+        """
+        self.repo_name = repo_name
+        self.pr_number = pr_number
+        self.auto_fix = auto_fix
+        self.github_token = github_token
+
+    async def _get_github_service(self) -> GitHubService:
+        """
+        Get a GitHub service instance with appropriate authentication.
+
+        Returns:
+            An authenticated GitHub service instance
+        """
+        # Use provided token or system token
+        token = self.github_token or SecretStr(os.environ.get('GITHUB_TOKEN', ''))
+
+        # Create GitHub service
+        return GitHubService(token=token)
+
+    async def _fetch_pr_details(self, github_service: GitHubService) -> dict[str, Any]:
+        """
+        Fetch PR details from GitHub.
+
+        Args:
+            github_service: The GitHub service to use for API calls
+
+        Returns:
+            PR details including title, body, and branches
+        """
+        url = f'{github_service.BASE_URL}/repos/{self.repo_name}/pulls/{self.pr_number}'
+        pr_data, _ = await github_service._make_request(url, method=RequestMethod.GET)
+
+        return {
+            'title': pr_data.get('title', ''),
+            'body': pr_data.get('body', ''),
+            'head_branch': pr_data.get('head', {}).get('ref', ''),
+            'base_branch': pr_data.get('base', {}).get('ref', ''),
+            'user': pr_data.get('user', {}).get('login', ''),
+            'html_url': pr_data.get('html_url', ''),
+        }
+
+    async def _fetch_pr_files(
+        self, github_service: GitHubService
+    ) -> list[dict[str, Any]]:
+        """
+        Fetch files changed in the PR.
+
+        Args:
+            github_service: The GitHub service to use for API calls
+
+        Returns:
+            List of files changed in the PR
+        """
+        url = f'{github_service.BASE_URL}/repos/{self.repo_name}/pulls/{self.pr_number}/files'
+        files_data, _ = await github_service._make_request(
+            url, method=RequestMethod.GET
+        )
+
+        return files_data
+
+    async def _create_conversation(
+        self, pr_details: dict[str, Any], pr_files: list[dict[str, Any]]
+    ) -> str:
+        """
+        Create a new conversation for PR review.
+
+        Args:
+            pr_details: PR details including title, body, and branches
+            pr_files: List of files changed in the PR
+
+        Returns:
+            The ID of the created conversation
+        """
+        # Format PR information for the initial message
+        pr_title = pr_details['title']
+        pr_body = pr_details['body']
+        pr_url = pr_details['html_url']
+        head_branch = pr_details['head_branch']
+        base_branch = pr_details['base_branch']
+
+        # Format files information
+        files_info = []
+        for file in pr_files:
+            filename = file.get('filename', '')
+            status = file.get('status', '')
+            additions = file.get('additions', 0)
+            deletions = file.get('deletions', 0)
+            changes = file.get('changes', 0)
+
+            files_info.append(
+                f'- {filename} ({status}): +{additions} -{deletions} ({changes} total changes)'
+            )
+
+        files_summary = '\n'.join(files_info)
+
+        # Create initial message
+        initial_message = f"""
+# PR Review: {pr_title}
+
+## PR Information
+- Repository: {self.repo_name}
+- PR Number: {self.pr_number}
+- PR URL: {pr_url}
+- Head Branch: {head_branch}
+- Base Branch: {base_branch}
+
+## PR Description
+{pr_body}
+
+## Files Changed
+{files_summary}
+
+Please review this PR and provide feedback on:
+1. Code quality and best practices
+2. Potential bugs or issues
+3. Performance considerations
+4. Security concerns
+5. Suggested improvements
+
+If you find issues that need fixing, please create a new PR with the necessary changes.
+"""
+
+        # Create conversation
+        import uuid
+
+        from openhands.server.services.conversation_service import (
+            create_new_conversation,
+        )
+
+        # Generate a new conversation ID
+        conversation_id = uuid.uuid4().hex
+
+        # Create the conversation with the initial message
+        ConversationInitData()
+
+        # Use the existing create_new_conversation function
+        await create_new_conversation(
+            user_id=None,  # Webhook-triggered conversations don't have a user ID
+            git_provider_tokens=None,
+            custom_secrets=None,
+            selected_repository=self.repo_name,
+            selected_branch=None,
+            initial_user_msg=initial_message,
+            image_urls=None,
+            replay_json=None,
+            conversation_instructions=None,
+            conversation_trigger=ConversationTrigger.GUI,  # Use GUI as fallback since API is not defined
+            attach_convo_id=False,
+            git_provider=None,
+            conversation_id=conversation_id,
+        )
+
+        return conversation_id
+
+    async def _add_pr_diff_to_conversation(
+        self,
+        conversation_id: str,
+        github_service: GitHubService,
+        pr_files: list[dict[str, Any]],
+    ) -> None:
+        """
+        Add PR diff information to the conversation.
+
+        Args:
+            conversation_id: The ID of the conversation
+            github_service: The GitHub service to use for API calls
+            pr_files: List of files changed in the PR
+        """
+        # For each file, fetch the diff and add it to the conversation
+        for file in pr_files:
+            filename = file.get('filename', '')
+            status = file.get('status', '')
+            patch = file.get('patch', '')
+
+            if not patch and status != 'removed':
+                # If patch is not included in the API response, fetch the file content
+                try:
+                    file_url = f'{github_service.BASE_URL}/repos/{self.repo_name}/contents/{filename}'
+                    params = {
+                        'ref': file.get('blob_url', '').split('/')[-2]
+                    }  # Extract commit SHA
+                    file_data, _ = await github_service._make_request(
+                        file_url, params=params, method=RequestMethod.GET
+                    )
+
+                    if file_data.get('type') == 'file':
+                        content = f'File: {filename} (New file)\n\n```\n{file_data.get("content", "")}\n```'
+
+                        # Add file content to conversation
+                        from openhands.events.action.message import MessageAction
+
+                        # Create a message action
+                        message_action = MessageAction(content=content)
+
+                        # Send the message to the conversation
+                        await conversation_manager.send_event_to_conversation(
+                            conversation_id,
+                            {
+                                'type': EventType.MESSAGE.value,
+                                'data': dataclasses.asdict(message_action),
+                            },
+                        )
+                except Exception as e:
+                    logger.error(f'Error fetching file content for {filename}: {e}')
+            elif patch:
+                # Add patch to conversation
+                content = f'File: {filename} ({status})\n\n```diff\n{patch}\n```'
+
+                # Create a message action
+                message_action = MessageAction(content=content)
+
+                # Send the message to the conversation
+                await conversation_manager.send_event_to_conversation(
+                    conversation_id,
+                    {
+                        'type': EventType.MESSAGE.value,
+                        'data': dataclasses.asdict(message_action),
+                    },
+                )
+
+    async def _add_review_request_to_conversation(self, conversation_id: str) -> None:
+        """
+        Add a review request message to the conversation.
+
+        Args:
+            conversation_id: The ID of the conversation
+        """
+        review_request = """
+Now that you've seen the PR changes, please provide a comprehensive review of the code. Include:
+
+1. A summary of the changes
+2. Code quality assessment
+3. Potential bugs or issues
+4. Performance considerations
+5. Security concerns
+6. Suggested improvements
+
+If there are issues that need fixing, please describe them in detail.
+"""
+
+        # Create a message action
+        from openhands.events.action.message import MessageAction
+
+        message_action = MessageAction(content=review_request)
+
+        # Send the message to the conversation
+        await conversation_manager.send_event_to_conversation(
+            conversation_id,
+            {
+                'type': EventType.MESSAGE.value,
+                'data': dataclasses.asdict(message_action),
+            },
+        )
+
+    async def _post_review_comment(
+        self, github_service: GitHubService, conversation_id: str, review_content: str
+    ) -> None:
+        """
+        Post a review comment on the PR.
+
+        Args:
+            github_service: The GitHub service to use for API calls
+            conversation_id: The ID of the conversation
+            review_content: The content of the review
+        """
+        # Add link to the conversation
+        # Use the server URL from environment or default to localhost
+        server_url = os.environ.get('SERVER_URL', 'http://localhost:3000')
+        conversation_url = f'{server_url}/conversation/{conversation_id}'
+        review_with_link = f'{review_content}\n\n---\n*This review was generated by OpenHands AI. [View the full conversation]({conversation_url}).*'
+
+        # Create review
+        url = f'{github_service.BASE_URL}/repos/{self.repo_name}/pulls/{self.pr_number}/reviews'
+        payload = {
+            'body': review_with_link,
+            'event': 'COMMENT',  # Could be APPROVE, REQUEST_CHANGES, or COMMENT
+        }
+
+        await github_service._make_request(
+            url=url, params=payload, method=RequestMethod.POST
+        )
+
+    async def _create_fix_pr(
+        self,
+        github_service: GitHubService,
+        conversation_id: str,
+        pr_details: dict[str, Any],
+    ) -> Optional[str]:
+        """
+        Create a new PR with suggested fixes.
+
+        This is a placeholder for future implementation. The actual implementation would:
+        1. Create a new branch based on the PR head branch
+        2. Apply suggested fixes
+        3. Create a new PR targeting the original PR branch
+
+        Args:
+            github_service: The GitHub service to use for API calls
+            conversation_id: The ID of the conversation
+            pr_details: PR details including branches
+
+        Returns:
+            URL of the created PR, if successful
+        """
+        # This is a placeholder - actual implementation would require more complex logic
+        # to create a branch, apply fixes, and create a PR
+        logger.info(
+            f'Auto-fix not implemented yet for PR #{self.pr_number} in {self.repo_name}'
+        )
+        return None
+
+    async def review_pr(self) -> dict[str, Any]:
+        """
+        Review a GitHub pull request.
+
+        This method:
+        1. Fetches PR details and files
+        2. Creates a new conversation
+        3. Adds PR diff information to the conversation
+        4. Requests a review from the AI
+        5. Optionally creates a new PR with fixes
+
+        Returns:
+            A dictionary with the review results
+        """
+        # Get GitHub service
+        github_service = await self._get_github_service()
+
+        # Fetch PR details and files
+        pr_details = await self._fetch_pr_details(github_service)
+        pr_files = await self._fetch_pr_files(github_service)
+
+        # Create conversation
+        conversation_id = await self._create_conversation(pr_details, pr_files)
+
+        # Add PR diff to conversation
+        await self._add_pr_diff_to_conversation(
+            conversation_id, github_service, pr_files
+        )
+
+        # Add review request
+        await self._add_review_request_to_conversation(conversation_id)
+
+        # The AI will now process the conversation and generate a review
+        # We don't wait for the review to complete, as it may take some time
+
+        # Return result with conversation ID
+        result = {
+            'conversation_id': conversation_id,
+            'pr_number': self.pr_number,
+            'repo_name': self.repo_name,
+        }
+
+        return result

--- a/openhands/server/app.py
+++ b/openhands/server/app.py
@@ -28,6 +28,7 @@ from openhands.server.routes.secrets import app as secrets_router
 from openhands.server.routes.security import app as security_api_router
 from openhands.server.routes.settings import app as settings_router
 from openhands.server.routes.trajectory import app as trajectory_router
+from openhands.server.routes.webhooks import app as webhooks_router
 from openhands.server.shared import conversation_manager
 
 mcp_app = mcp_server.http_app(path='/mcp')
@@ -70,4 +71,5 @@ app.include_router(settings_router)
 app.include_router(secrets_router)
 app.include_router(git_api_router)
 app.include_router(trajectory_router)
+app.include_router(webhooks_router)
 add_health_endpoints(app)

--- a/openhands/server/config/server_config.py
+++ b/openhands/server/config/server_config.py
@@ -14,6 +14,13 @@ class ServerConfig(ServerConfigInterface):
     hide_llm_settings = os.environ.get('HIDE_LLM_SETTINGS', 'false') == 'true'
     # This config is used to hide the microagent management page from the users for now. We will remove this once we release the new microagent management page.
     hide_microagent_management = True
+
+    # Webhook configuration
+    webhook_secret = os.environ.get('WEBHOOK_SECRET', '')
+    webhook_allowed_repositories = os.environ.get('WEBHOOK_ALLOWED_REPOS', '').split(
+        ','
+    )
+    webhook_auto_fix = os.environ.get('WEBHOOK_AUTO_FIX', 'false') == 'true'
     settings_store_class: str = (
         'openhands.storage.settings.file_settings_store.FileSettingsStore'
     )
@@ -45,6 +52,11 @@ class ServerConfig(ServerConfigInterface):
                 'ENABLE_BILLING': self.enable_billing,
                 'HIDE_LLM_SETTINGS': self.hide_llm_settings,
                 'HIDE_MICROAGENT_MANAGEMENT': self.hide_microagent_management,
+            },
+            'WEBHOOK_CONFIG': {
+                'SECRET': self.webhook_secret,
+                'ALLOWED_REPOSITORIES': self.webhook_allowed_repositories,
+                'AUTO_FIX': self.webhook_auto_fix,
             },
         }
 

--- a/openhands/server/routes/webhooks.py
+++ b/openhands/server/routes/webhooks.py
@@ -1,0 +1,182 @@
+import hashlib
+import hmac
+import json
+from typing import Any, Optional
+
+from fastapi import APIRouter, Header, HTTPException, Request, status
+from pydantic import BaseModel, Field
+
+from openhands.core.logger import openhands_logger as logger
+from openhands.integrations.github.pr_reviewer import PRReviewer
+from openhands.server.dependencies import get_dependencies
+from openhands.server.shared import server_config
+
+app = APIRouter(prefix='/api/webhooks', dependencies=get_dependencies())
+
+
+class WebhookConfig(BaseModel):
+    """Configuration for webhook processing."""
+
+    secret: Optional[str] = Field(
+        None, description='Secret for validating webhook signatures'
+    )
+    allowed_repositories: list[str] = Field(
+        default_factory=list,
+        description='List of repositories allowed to trigger reviews (format: owner/repo)',
+    )
+    auto_fix: bool = Field(
+        False, description='Whether to automatically create PRs with fixes'
+    )
+
+
+# Load configuration from server_config
+webhook_config = WebhookConfig(
+    secret=server_config.webhook_secret,
+    allowed_repositories=[
+        repo for repo in server_config.webhook_allowed_repositories if repo
+    ],
+    auto_fix=server_config.webhook_auto_fix,
+)
+
+
+def verify_signature(payload: bytes, signature_header: str, secret: str) -> bool:
+    """
+    Verify the webhook signature using the secret.
+
+    Args:
+        payload: The raw request payload
+        signature_header: The signature header from GitHub (X-Hub-Signature-256)
+        secret: The webhook secret
+
+    Returns:
+        True if signature is valid, False otherwise
+    """
+    if not signature_header.startswith('sha256='):
+        return False
+
+    signature = signature_header[7:]  # Remove 'sha256=' prefix
+
+    # Create HMAC with SHA256
+    mac = hmac.new(secret.encode(), msg=payload, digestmod=hashlib.sha256)
+    expected_signature = mac.hexdigest()
+
+    # Compare signatures using constant-time comparison
+    return hmac.compare_digest(signature, expected_signature)
+
+
+@app.post('/github')
+async def github_webhook(
+    request: Request,
+    x_github_event: str = Header(..., alias='X-GitHub-Event'),
+    x_hub_signature_256: Optional[str] = Header(None, alias='X-Hub-Signature-256'),
+):
+    """
+    Handle GitHub webhook events.
+
+    This endpoint receives webhook events from GitHub and processes them based on the event type.
+    Currently supports:
+    - pull_request events (opened, synchronize)
+
+    Args:
+        request: The FastAPI request object
+        x_github_event: The GitHub event type
+        x_hub_signature_256: The GitHub signature for verification
+
+    Returns:
+        A JSON response indicating the result of processing the webhook
+    """
+    # Read raw payload
+    payload_bytes = await request.body()
+
+    # Verify signature if secret is configured
+    if webhook_config.secret and x_hub_signature_256:
+        if not verify_signature(
+            payload_bytes, x_hub_signature_256, webhook_config.secret
+        ):
+            logger.warning('Invalid webhook signature')
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail='Invalid signature',
+            )
+
+    # Parse payload
+    try:
+        payload = json.loads(payload_bytes)
+    except json.JSONDecodeError:
+        logger.error('Invalid JSON payload in webhook')
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail='Invalid JSON payload',
+        )
+
+    # Process based on event type
+    if x_github_event == 'pull_request':
+        return await handle_pull_request_event(payload)
+    elif x_github_event == 'ping':
+        return {'message': 'Webhook received successfully'}
+    else:
+        logger.info(f'Unhandled GitHub event: {x_github_event}')
+        return {'message': f'Event type {x_github_event} not handled'}
+
+
+async def handle_pull_request_event(payload: dict[str, Any]) -> dict[str, Any]:
+    """
+    Handle GitHub pull request events.
+
+    Args:
+        payload: The webhook payload
+
+    Returns:
+        A JSON response indicating the result of processing the event
+    """
+    action = payload.get('action')
+    pr_data = payload.get('pull_request', {})
+    repository = payload.get('repository', {})
+
+    # Only process opened or synchronized PRs
+    if action not in ['opened', 'synchronize']:
+        return {'message': f'PR action {action} not handled'}
+
+    repo_name = repository.get('full_name')
+
+    # Check if repository is in allowed list
+    if (
+        webhook_config.allowed_repositories
+        and repo_name not in webhook_config.allowed_repositories
+    ):
+        logger.info(f'Repository {repo_name} not in allowed list')
+        return {'message': f'Repository {repo_name} not configured for PR reviews'}
+
+    # Extract PR information
+    pr_number = pr_data.get('number')
+    pr_title = pr_data.get('title')
+    pr_data.get('body') or ''
+    pr_data.get('head', {}).get('ref')
+    pr_data.get('base', {}).get('ref')
+
+    logger.info(f'Processing PR #{pr_number} in {repo_name}: {pr_title}')
+
+    try:
+        # Initialize PR reviewer
+        reviewer = PRReviewer(
+            repo_name=repo_name,
+            pr_number=pr_number,
+            auto_fix=webhook_config.auto_fix,
+        )
+
+        # Start review process
+        review_result = await reviewer.review_pr()
+
+        return {
+            'message': 'PR review initiated',
+            'pr_number': pr_number,
+            'repo': repo_name,
+            'conversation_id': review_result.get('conversation_id'),
+        }
+    except Exception as e:
+        logger.error(f'Error processing PR review: {e}', exc_info=True)
+        return {
+            'message': f'Error processing PR review: {str(e)}',
+            'pr_number': pr_number,
+            'repo': repo_name,
+        }


### PR DESCRIPTION
## Description

This PR adds an automated PR reviewer workflow to OpenHands, triggered by GitHub webhooks. The implementation includes:

1. A webhook endpoint in the server to receive GitHub PR events
2. A PR reviewer service that analyzes code changes and provides feedback
3. Integration with the conversation system to create new conversations for PR reviews
4. Configuration options for webhook secrets and allowed repositories

## Features

- Detects new PRs for configured repositories
- Initiates a new conversation in OpenHands for that project
- Analyzes the code changes in the PR using AI
- Flags any issues or required improvements
- Posts review comments back to GitHub

## Configuration

The following environment variables can be set:
- `WEBHOOK_SECRET`: Secret for validating GitHub webhook signatures
- `WEBHOOK_ALLOWED_REPOS`: Comma-separated list of repositories allowed to trigger reviews
- `WEBHOOK_AUTO_FIX`: Enable/disable automatic fix generation (future enhancement)

## Future Enhancements

- Implement automatic fix generation with PR creation
- Add support for other Git providers (GitLab, Bitbucket)
- Add unit tests for the webhook and PR reviewer functionality